### PR TITLE
Add get_workspace_count

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -111,6 +111,7 @@ register_cfunctions(lua_State *lua)
 
 	lua_register(lua,"set_window_workspace",c_set_window_workspace);
 	lua_register(lua,"change_workspace",c_change_workspace);
+	lua_register(lua,"get_workspace_count",c_get_workspace_count);
 
 	lua_register(lua,"pin_window",c_pin_window);
 	lua_register(lua,"unpin_window",c_unpin_window);

--- a/src/script_functions.c
+++ b/src/script_functions.c
@@ -725,6 +725,34 @@ int c_change_workspace(lua_State *lua)
 
 
 /**
+ * Return workspace count
+ */
+int c_get_workspace_count(lua_State *lua)
+{
+	int count=0;
+	int top=lua_gettop(lua);
+
+	if (top!=0) {
+		luaL_error(lua,"get_window_class: %s",no_indata_expected_error);
+		return 0;
+	}
+
+	WnckWindow *window=get_current_window();
+
+	if (window) {
+		WnckScreen *screen;
+
+		screen=wnck_window_get_screen(window);
+		count=wnck_screen_get_workspace_count(screen);
+	}
+
+	lua_pushnumber(lua,count);
+
+	return 1;
+}
+
+
+/**
  * Unmaximize window
  */
 int c_unmaximize_window(lua_State *lua)

--- a/src/script_functions.h
+++ b/src/script_functions.h
@@ -53,6 +53,7 @@ int c_undecorate_window(lua_State *lua);
 
 int c_set_window_workspace(lua_State *lua);
 int c_change_workspace(lua_State *lua);
+int c_get_workspace_count(lua_State *lua);
 
 int c_unmaximize_window(lua_State *lua);
 int c_maximize_window(lua_State *lua);


### PR DESCRIPTION
Adds a function for getting total number of workspaces, useful if you want to move windows to last workspace (or relative to it) without hardcoding total number of workspaces
