### PR TITLE
set_window_strut function

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -84,6 +84,7 @@ register_cfunctions(lua_State *lua)
 	lua_register(lua, "set_window_position", c_set_window_position);
 	lua_register(lua, "set_window_position2", c_set_window_position2);
 	lua_register(lua, "set_window_size", c_set_window_size);
+	lua_register(lua, "set_window_strut", c_set_window_strut);
 
 	lua_register(lua, "set_window_geometry", c_set_window_geometry);
 	lua_register(lua, "set_window_geometry2", c_set_window_geometry2);

--- a/src/script_functions.c
+++ b/src/script_functions.c
@@ -355,6 +355,42 @@ int c_set_window_size(lua_State *lua)
 	return 0;
 }
 
+/**
+ * Sets the window strut
+ */
+int c_set_window_strut(lua_State *lua)
+{
+	int top = lua_gettop(lua);
+
+	if (top < 4) {
+		luaL_error(lua,"set_window_strut: %s", four_indata_expected_error);
+		return 0;
+	}
+
+	if (!devilspie2_emulate) {
+		int64_t struts[12];
+		int i;
+		for (i = 0; i < 12; i++) {
+			struts[i] = i < top ? lua_tonumber(lua, i + 1) : 0;
+		}
+
+		Display *dpy = gdk_x11_get_default_xdisplay();
+		WnckWindow *window = get_current_window();
+
+		if (window) {
+			XChangeProperty(dpy,
+							wnck_window_get_xid(window),
+							XInternAtom(dpy, "_NET_WM_STRUT_PARTIAL", False), XA_CARDINAL,
+							32,
+							PropModeReplace,
+							(unsigned char*)struts,
+							12);
+			XSync(dpy, False);
+		}
+	}
+
+	return 0;
+}
 
 /**
  * Sets the window on top of all others and locks it "always on top"

--- a/src/script_functions.h
+++ b/src/script_functions.h
@@ -34,6 +34,8 @@ int c_set_window_geometry2(lua_State *lua);
 
 int c_set_window_size(lua_State *lua);
 
+int c_set_window_strut(lua_State *lua);
+
 int c_make_always_on_top(lua_State *lua);
 
 int c_set_on_top(lua_State *lua);


### PR DESCRIPTION
Proposing a `set_window_strut` function which sets `_NET_WM_STRUT_PARTIAL` property which reserves space at the edge of the screen. E.g. I can write

```
if (get_application_name() == "Conky (desktop)") then
    set_window_size(1916, 16)
    set_window_strut(0, 0, 16, 0, 0, 0, 0, 0, 1920, 3840)
end

if (get_application_name() == "Pidgin" and get_window_role() == "conversation") then
    undecorate_window()
    set_skip_pager(true)
    set_skip_tasklist(true)
    set_window_geometry(1920 * 2 - 640, 600, 640, 480)
    set_window_strut(0, 640, 0, 0, 0, 0, 600, 1080, 0, 0, 0, 0)
end
```

Conky acts like a panel and maximized windows do not overlap pidgin conversation window (screenshot: http://storage.thelogin.ru/screenshots/2013-11-20_03:40:36.png)
